### PR TITLE
Ne pas imposer -O3 dans les options de compilation CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(nyx_node LANGUAGES C VERSION 1.0.0)
 
 set(CMAKE_C_STANDARD 99)
 
-add_compile_options(-D_GNU_SOURCE -DMG_ENABLE_LOG=0 -DMG_ENABLE_SSI=0 -Wall -Wno-unknown-pragmas -Wno-unused-function -O3)
+add_compile_options(-D_GNU_SOURCE -DMG_ENABLE_LOG=0 -DMG_ENABLE_SSI=0 -Wall -Wno-unknown-pragmas -Wno-unused-function)
 
 ########################################################################################################################
 


### PR DESCRIPTION
...car c'est le boulot de `-DCMAKE_BUILD_TYPE=Release`, et en le forçant à cet endroit on empêche la construction de builds `Debug` qui peuvent parfois être utiles...